### PR TITLE
Add support for SMB2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1")
 
-    implementation("org.codelibs:jcifs:1.3.18.3")
+    implementation("org.codelibs:jcifs:2.1.35")
     implementation("org.jsoup:jsoup:1.14.3")
     implementation("commons-io:commons-io:2.11.0")
     implementation("io.pebbletemplates:pebble:3.1.5")


### PR DESCRIPTION
This updates the used CIFS library to the latest version which adds support for SMB2, I adapted the code to the API changes.

Right now this still allows to use SMB1, for security reasons this could be disabled. Currently the maximum used SMB version is 2.1, this could be increased to 3.1.1, but the library claims only partial support and i don't know how well this works.